### PR TITLE
fix. workaround for TaskPaper3

### DIFF
--- a/platform/mac/src/server/MacFrontEnd.mm
+++ b/platform/mac/src/server/MacFrontEnd.mm
@@ -113,10 +113,14 @@ void MacFrontEnd::workaroundForBlacklistApp(NSString* string) {
 bool MacFrontEnd::isBlacklistApp() const {
   NSString* powerPoint = @"com.microsoft.powerpoint";
   NSString* pycharm = @"com.jetbrains.pycharm";
+  NSString* taskpaper = @"com.hogbaysoftware.TaskPaper3";
   if([[client_ bundleIdentifier] caseInsensitiveCompare:powerPoint] == NSOrderedSame) {
       return true;
   }
   if([[client_ bundleIdentifier] caseInsensitiveCompare:pycharm] == NSOrderedSame) {
+      return true;
+  }
+  if([[client_ bundleIdentifier] caseInsensitiveCompare:taskpaper] == NSOrderedSame) {
       return true;
   }
   return false;


### PR DESCRIPTION
TaskPaper3 では入力時に「できる」が「dでkきrる」のようになるため、ワークアラウンドを入れました
